### PR TITLE
Performance optimization for is-nil happy path

### DIFF
--- a/isNil_test.go
+++ b/isNil_test.go
@@ -1,8 +1,11 @@
 package multierr
 
-import "testing"
+import (
+	"errors"
+	"testing"
+)
 
-type estruct struct {}
+type estruct struct{}
 
 func (e estruct) Error() string {
 	return "I'm an error!"
@@ -36,4 +39,60 @@ func TestIsNil(t *testing.T) {
 	if !isNil(e) {
 		t.Fail()
 	}
+}
+
+var result bool
+
+func BenchmarkNilInterface(b *testing.B) {
+	var e error
+	var r bool
+	for n := 0; n < b.N; n++ {
+		r = isNil(e)
+	}
+	result = r
+}
+
+func BenchmarkNonNilInterface(b *testing.B) {
+	e := errors.New("foo")
+	var r bool
+	for n := 0; n < b.N; n++ {
+		r = isNil(e)
+	}
+	result = r
+}
+
+func BenchmarkNilStructPointer(b *testing.B) {
+	var e *estruct
+	var r bool
+	for n := 0; n < b.N; n++ {
+		r = isNil(e)
+	}
+	result = r
+}
+
+func BenchmarkNonNilStructPointer(b *testing.B) {
+	e := &estruct{}
+	var r bool
+	for n := 0; n < b.N; n++ {
+		r = isNil(e)
+	}
+	result = r
+}
+
+func BenchmarkNilSlice(b *testing.B) {
+	var e Error
+	var r bool
+	for n := 0; n < b.N; n++ {
+		r = isNil(e)
+	}
+	result = r
+}
+
+func BenchmarkNonNilSlice(b *testing.B) {
+	e := Error{errors.New("foo")}
+	var r bool
+	for n := 0; n < b.N; n++ {
+		r = isNil(e)
+	}
+	result = r
 }

--- a/multierr.go
+++ b/multierr.go
@@ -1,8 +1,8 @@
 package multierr
 
 import (
-	"strings"
 	"reflect"
+	"strings"
 )
 
 type Error []error
@@ -50,6 +50,9 @@ func Append(e1 error, e2 error) error {
 }
 
 func isNil(i interface{}) bool {
+	if i == nil {
+		return true
+	}
 	v := reflect.ValueOf(i)
 	switch v.Kind() {
 	case reflect.Invalid:


### PR DESCRIPTION
This is a little bit of a rabbit hole. Using equals to test for nil at the start of `isNil` improves the performance of the happy path when the input value is a nil interface value. I stared at the implementations of reflect.ValueOf(i) and v.Kind() and they don't seem to do very much when the input value is a nil interface. If I really cared I could dump the assembly but I didn't go that far.

Original performance:
```
$ go test -bench=. -benchtime 10s
goos: linux
goarch: amd64
pkg: github.com/jonbodner/multierr
BenchmarkNilInterface-4                 3000000000               4.84 ns/op
BenchmarkNonNilInterface-4              2000000000              10.6 ns/op
BenchmarkNilStructPointer-4             2000000000              10.3 ns/op
BenchmarkNonNilStructPointer-4          2000000000              10.3 ns/op
BenchmarkNilSlice-4                     1000000000              13.2 ns/op
BenchmarkNonNilSlice-4                  300000000               47.5 ns/op
PASS
ok      github.com/jonbodner/multierr   114.251s
```

Patch applied:

```
$ go test -bench=. -benchtime 10s
goos: linux
goarch: amd64
pkg: github.com/jonbodner/multierr
BenchmarkNilInterface-4                 10000000000              2.91 ns/op
BenchmarkNonNilInterface-4              2000000000              10.6 ns/op
BenchmarkNilStructPointer-4             2000000000              10.3 ns/op
BenchmarkNonNilStructPointer-4          2000000000              10.4 ns/op
BenchmarkNilSlice-4                     1000000000              13.5 ns/op
BenchmarkNonNilSlice-4                  300000000               47.9 ns/op
PASS
ok      github.com/jonbodner/multierr   129.209s
```